### PR TITLE
Add GenieKey scheme to Authorization header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ test: patch-haskell
 
 patch-haskell: generate-haskell
 	patch -p1 -i patches/0001-upgrade-to-lts-14.27.patch
+	patch -p1 -i patches/0002-geniekey-scheme.patch
 
 generate-haskell: patch-swagger
 	rm -rf $(GEN_OPSGENIE_REST)

--- a/gen/opsgenie-rest/lib/OpsgenieREST/API.hs
+++ b/gen/opsgenie-rest/lib/OpsgenieREST/API.hs
@@ -1466,7 +1466,7 @@ instance AuthMethod AuthApiKeyGenieKey where
   applyAuthMethod _ a@(AuthApiKeyGenieKey secret) req =
     P.pure $
     if (P.typeOf a `P.elem` rAuthTypes req)
-      then req `setHeader` toHeader ("Authorization", secret)
+      then req `setHeader` toHeader ("Authorization", "GenieKey " <> secret)
            & L.over rAuthTypesL (P.filter (/= P.typeOf a))
       else req
 

--- a/gen/opsgenie-rest/swagger.yaml
+++ b/gen/opsgenie-rest/swagger.yaml
@@ -5152,7 +5152,6 @@ definitions:
         x-dataType: "Integer"
       timeUnit:
         type: "string"
-        default: "minutes"
         enum:
         - "days"
         - "hours"
@@ -5161,6 +5160,7 @@ definitions:
         - "miliseconds"
         - "micros"
         - "nanos"
+        default: "minutes"
         x-dataType: "E'TimeUnit"
     x-opsgenie-domain: "common"
   Filter:

--- a/patches/0002-geniekey-scheme.patch
+++ b/patches/0002-geniekey-scheme.patch
@@ -1,0 +1,25 @@
+From 7b62b7cf9551c36d2a415af0f81986ecf24450be Mon Sep 17 00:00:00 2001
+From: "Ross A. Baker" <ross@rossabaker.com>
+Date: Thu, 5 Mar 2020 18:42:26 -0500
+Subject: [PATCH] Add GenieKey scheme to Authorization header
+
+---
+ gen/opsgenie-rest/lib/OpsgenieREST/API.hs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gen/opsgenie-rest/lib/OpsgenieREST/API.hs b/gen/opsgenie-rest/lib/OpsgenieREST/API.hs
+index ad44077..3d482c9 100644
+--- a/gen/opsgenie-rest/lib/OpsgenieREST/API.hs
++++ b/gen/opsgenie-rest/lib/OpsgenieREST/API.hs
+@@ -1466,7 +1466,7 @@ instance AuthMethod AuthApiKeyGenieKey where
+   applyAuthMethod _ a@(AuthApiKeyGenieKey secret) req =
+     P.pure $
+     if (P.typeOf a `P.elem` rAuthTypes req)
+-      then req `setHeader` toHeader ("Authorization", secret)
++      then req `setHeader` toHeader ("Authorization", "GenieKey " <> secret)
+            & L.over rAuthTypesL (P.filter (/= P.typeOf a))
+       else req
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Swagger v2 has no way to declare the scheme in the Authorization header, so the Opsgenie API rightly rejects it with a 401.