### PR TITLE
Drop upper bound on time

### DIFF
--- a/gen/opsgenie-rest/opsgenie-rest.cabal
+++ b/gen/opsgenie-rest/opsgenie-rest.cabal
@@ -46,7 +46,7 @@ library
     , http-api-data >= 0.4.1.1
     , http-media >= 0.8.0.0
     , text >=0.11 && <1.3
-    , time >=1.5 && <1.9
+    , time >=1.5
     , iso8601-time >=0.1.3
     , vector >=0.10.9
     , network >=2.8.0.1

--- a/patches/0001-upgrade-to-lts-14.27.patch
+++ b/patches/0001-upgrade-to-lts-14.27.patch
@@ -46,10 +46,11 @@ index ee90488..c717f79 100644
 +    , http-api-data >= 0.4.1.1
 +    , http-media >= 0.8.0.0
      , text >=0.11 && <1.3
-     , time >=1.5 && <1.9
+-    , time >=1.5 && <1.9
 -    , iso8601-time >=0.1.3 && <0.2.0
 -    , vector >=0.10.9 && <0.13
 -    , network >=2.6.2 && <2.7
++    , time >=1.5
 +    , iso8601-time >=0.1.3
 +    , vector >=0.10.9
 +    , network >=2.8.0.1


### PR DESCRIPTION
The upper bound is currently overconstrained for lts-15.8.  Drop it, as we have for others.